### PR TITLE
[FIX] dDay 필드 이름 관련 버그

### DIFF
--- a/src/main/java/efub/eday/edayback/domain/day/dday/entity/DDay.java
+++ b/src/main/java/efub/eday/edayback/domain/day/dday/entity/DDay.java
@@ -1,22 +1,21 @@
 package efub.eday.edayback.domain.day.dday.entity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+public enum Dday {
+	SEVEN(7),
+	SIX(6),
+	FIVE(5),
+	FOUR(4),
+	THREE(3),
+	TWO(2),
+	ONE(1);
 
-@Entity
-public class DDay {
+	private final int remainingDays;
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "d_day_id")
-	private Long id;
+	Dday(int remainingDays) {
+		this.remainingDays = remainingDays;
+	}
 
-	@Column(name = "d_day", nullable = false)
-	private int dDay;
-
-	@Column(nullable = false)
-	private String topic;
+	public int getRemainingDays() {
+		return remainingDays;
+	}
 }

--- a/src/main/java/efub/eday/edayback/domain/day/dday/entity/Subject.java
+++ b/src/main/java/efub/eday/edayback/domain/day/dday/entity/Subject.java
@@ -1,0 +1,25 @@
+package efub.eday.edayback.domain.day.dday.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Subject {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "subject_id")
+	private Long id;
+
+	@Enumerated(value = EnumType.ORDINAL)
+	@Column(name = "d_day", nullable = false)
+	private int dday;
+
+	@Column(nullable = false)
+	private String headline;
+}

--- a/src/main/java/efub/eday/edayback/domain/day/dday/entity/Subject.java
+++ b/src/main/java/efub/eday/edayback/domain/day/dday/entity/Subject.java
@@ -18,8 +18,12 @@ public class Subject {
 
 	@Enumerated(value = EnumType.ORDINAL)
 	@Column(name = "d_day", nullable = false)
-	private int dday;
+	private Dday dday;
 
 	@Column(nullable = false)
 	private String headline;
+
+	public int getDday() {
+		return dday.getRemainingDays();
+	}
 }

--- a/src/main/java/efub/eday/edayback/domain/day/info/controller/InfoController.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/controller/InfoController.java
@@ -1,0 +1,27 @@
+package efub.eday.edayback.domain.day.info.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import efub.eday.edayback.domain.day.info.dto.InfoDto;
+import efub.eday.edayback.domain.day.info.entity.Info;
+import efub.eday.edayback.domain.day.info.service.InfoService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/infos")
+@RequiredArgsConstructor
+public class InfoController {
+	private final InfoService infoService;
+
+	@GetMapping("/{d_day}")
+	@ResponseStatus(value = HttpStatus.OK)
+	public InfoDto getInfoByDDay(@PathVariable("d_day") int dDay) {
+		Info info = infoService.getInfoByDDay(dDay);
+		return InfoDto.from(info);
+	}
+}

--- a/src/main/java/efub/eday/edayback/domain/day/info/controller/InfoController.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/controller/InfoController.java
@@ -20,8 +20,8 @@ public class InfoController {
 
 	@GetMapping("/{d_day}")
 	@ResponseStatus(value = HttpStatus.OK)
-	public InfoDto getInfoByDDay(@PathVariable("d_day") int dDay) {
-		Info info = infoService.getInfoByDDay(dDay);
+	public InfoDto getInfoByDDay(@PathVariable("d_day") int dday) {
+		Info info = infoService.getInfoByDday(dday);
 		return InfoDto.from(info);
 	}
 }

--- a/src/main/java/efub/eday/edayback/domain/day/info/dto/ImageDto.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/dto/ImageDto.java
@@ -1,0 +1,11 @@
+package efub.eday.edayback.domain.day.info.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ImageDto {
+	private Long imageId;
+	private String imageUrl;
+}

--- a/src/main/java/efub/eday/edayback/domain/day/info/dto/InfoDto.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/dto/InfoDto.java
@@ -22,7 +22,7 @@ public class InfoDto {
 	public static InfoDto from(Info info) {
 		InfoDto infoDto = new InfoDto();
 		infoDto.setInfoId(info.getId());
-		infoDto.setDDay(info.getDDay().getDDay());
+		infoDto.setDDay(info.getSubject().getDday());
 
 		List<ImageDto> imageList = new ArrayList<>();
 		for (InfoImage infoImage : info.getInfoImageList()) {

--- a/src/main/java/efub/eday/edayback/domain/day/info/dto/InfoDto.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/dto/InfoDto.java
@@ -1,0 +1,39 @@
+package efub.eday.edayback.domain.day.info.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import efub.eday.edayback.domain.day.info.entity.Info;
+import efub.eday.edayback.domain.day.info.entity.InfoImage;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InfoDto {
+	private Long infoId;
+	private Long infoImageId;
+	private int dDay;
+	private List<ImageDto> imageList;
+
+	public static InfoDto from(Info info) {
+		InfoDto infoDto = new InfoDto();
+		infoDto.setInfoId(info.getId());
+		infoDto.setDDay(info.getDDay().getDDay());
+
+		List<ImageDto> imageList = new ArrayList<>();
+		for (InfoImage infoImage : info.getInfoImageList()) {
+			ImageDto imageDto = new ImageDto();
+			imageDto.setImageId(infoImage.getId());
+			imageDto.setImageUrl(infoImage.getUrl());
+			imageList.add(imageDto);
+		}
+		infoDto.setImageList(imageList);
+
+		return infoDto;
+	}
+}
+

--- a/src/main/java/efub/eday/edayback/domain/day/info/entity/Info.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/entity/Info.java
@@ -1,5 +1,7 @@
 package efub.eday.edayback.domain.day.info.entity;
 
+import java.util.List;
+
 import efub.eday.edayback.domain.day.dday.entity.DDay;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -7,9 +9,15 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
+@Getter
 public class Info {
 
 	@Id
@@ -17,7 +25,17 @@ public class Info {
 	@Column(name = "info_id")
 	private Long id;
 
-	@OneToOne
+	@OneToOne(mappedBy = "info")
 	@JoinColumn(name = "d_day_id")
 	private DDay dDay;
+
+	@OneToMany(mappedBy = "info")
+	private List<InfoImage> infoImageList;
+
+	@Builder
+	public Info(Long id, DDay dDay, List<InfoImage> infoImageList) {
+		this.id = id;
+		this.dDay = dDay;
+		this.infoImageList = infoImageList;
+	}
 }

--- a/src/main/java/efub/eday/edayback/domain/day/info/entity/Info.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/entity/Info.java
@@ -2,7 +2,7 @@ package efub.eday.edayback.domain.day.info.entity;
 
 import java.util.List;
 
-import efub.eday.edayback.domain.day.dday.entity.DDay;
+import efub.eday.edayback.domain.day.dday.entity.Subject;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -25,17 +25,17 @@ public class Info {
 	@Column(name = "info_id")
 	private Long id;
 
-	@OneToOne(mappedBy = "info")
-	@JoinColumn(name = "d_day_id")
-	private DDay dDay;
+	@OneToOne
+	@JoinColumn(name = "subject_id", nullable = false)
+	private Subject subject;
 
 	@OneToMany(mappedBy = "info")
 	private List<InfoImage> infoImageList;
 
 	@Builder
-	public Info(Long id, DDay dDay, List<InfoImage> infoImageList) {
+	public Info(Long id, Subject subject, List<InfoImage> infoImageList) {
 		this.id = id;
-		this.dDay = dDay;
+		this.subject = subject;
 		this.infoImageList = infoImageList;
 	}
 }

--- a/src/main/java/efub/eday/edayback/domain/day/info/entity/InfoImage.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/entity/InfoImage.java
@@ -6,9 +6,14 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
+@Getter
 public class InfoImage {
 
 	@Id
@@ -19,7 +24,14 @@ public class InfoImage {
 	@Column(name = "image_url")
 	private String url;
 
-	@OneToOne
+	@ManyToOne
 	@JoinColumn(name = "info_id")
 	private Info info;
+
+	@Builder
+	public InfoImage(Long id, String url, Info info) {
+		this.id = id;
+		this.url = url;
+		this.info = info;
+	}
 }

--- a/src/main/java/efub/eday/edayback/domain/day/info/repository/InfoRepository.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/repository/InfoRepository.java
@@ -1,0 +1,9 @@
+package efub.eday.edayback.domain.day.info.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import efub.eday.edayback.domain.day.info.entity.Info;
+
+public interface InfoRepository extends JpaRepository<Info, Long> {
+	Info findByDDay_DDay(int dDay);
+}

--- a/src/main/java/efub/eday/edayback/domain/day/info/repository/InfoRepository.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/repository/InfoRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import efub.eday.edayback.domain.day.info.entity.Info;
 
 public interface InfoRepository extends JpaRepository<Info, Long> {
-	Optional<Info> findByDDay_DDay(int dDay);
+	Optional<Info> findInfoBySubject_Dday(int dday);
 }

--- a/src/main/java/efub/eday/edayback/domain/day/info/repository/InfoRepository.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/repository/InfoRepository.java
@@ -1,9 +1,11 @@
 package efub.eday.edayback.domain.day.info.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import efub.eday.edayback.domain.day.info.entity.Info;
 
 public interface InfoRepository extends JpaRepository<Info, Long> {
-	Info findByDDay_DDay(int dDay);
+	Optional<Info> findByDDay_DDay(int dDay);
 }

--- a/src/main/java/efub/eday/edayback/domain/day/info/service/InfoService.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/service/InfoService.java
@@ -14,8 +14,8 @@ public class InfoService {
 	private final InfoRepository infoRepository;
 
 	@Transactional(readOnly = true)
-	public Info getInfoByDDay(int dDay) {
-		return infoRepository.findByDDay_DDay(dDay)
+	public Info getInfoByDday(int dday) {
+		return infoRepository.findInfoBySubject_Dday(dday)
 			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 추가정보입니다."));
 	}
 }

--- a/src/main/java/efub/eday/edayback/domain/day/info/service/InfoService.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/service/InfoService.java
@@ -1,0 +1,20 @@
+package efub.eday.edayback.domain.day.info.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import efub.eday.edayback.domain.day.info.entity.Info;
+import efub.eday.edayback.domain.day.info.repository.InfoRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class InfoService {
+	private final InfoRepository infoRepository;
+
+	@Transactional(readOnly = true)
+	public Info getInfoByDDay(int dDay) {
+		return infoRepository.findByDDay_DDay(dDay);
+	}
+}

--- a/src/main/java/efub/eday/edayback/domain/day/info/service/InfoService.java
+++ b/src/main/java/efub/eday/edayback/domain/day/info/service/InfoService.java
@@ -15,6 +15,7 @@ public class InfoService {
 
 	@Transactional(readOnly = true)
 	public Info getInfoByDDay(int dDay) {
-		return infoRepository.findByDDay_DDay(dDay);
+		return infoRepository.findByDDay_DDay(dDay)
+			.orElseThrow(() -> new IllegalArgumentException("존재하지 않는 추가정보입니다."));
 	}
 }

--- a/src/main/java/efub/eday/edayback/domain/day/quiz/entity/Quiz.java
+++ b/src/main/java/efub/eday/edayback/domain/day/quiz/entity/Quiz.java
@@ -1,6 +1,6 @@
 package efub.eday.edayback.domain.day.quiz.entity;
 
-import efub.eday.edayback.domain.day.dday.entity.DDay;
+import efub.eday.edayback.domain.day.dday.entity.Subject;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -27,6 +27,6 @@ public class Quiz {
 	private String imageUrl;
 
 	@OneToOne
-	@JoinColumn(name = "d_day_id", nullable = false)
-	private DDay dDay;
+	@JoinColumn(nullable = false)
+	private Subject subject;
 }

--- a/src/main/java/efub/eday/edayback/domain/day/title/entity/Title.java
+++ b/src/main/java/efub/eday/edayback/domain/day/title/entity/Title.java
@@ -1,6 +1,6 @@
 package efub.eday.edayback.domain.day.title.entity;
 
-import efub.eday.edayback.domain.day.dday.entity.DDay;
+import efub.eday.edayback.domain.day.dday.entity.Subject;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -24,6 +24,6 @@ public class Title {
 	private String imageUrl;
 
 	@OneToOne
-	@JoinColumn(name = "d_day_id", nullable = false)
-	private DDay dDay;
+	@JoinColumn(nullable = false)
+	private Subject subject;
 }

--- a/src/main/java/efub/eday/edayback/domain/query/entity/Query.java
+++ b/src/main/java/efub/eday/edayback/domain/query/entity/Query.java
@@ -1,6 +1,6 @@
 package efub.eday.edayback.domain.query.entity;
 
-import efub.eday.edayback.domain.day.dday.entity.DDay;
+import efub.eday.edayback.domain.day.dday.entity.Subject;
 import efub.eday.edayback.domain.member.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -26,6 +26,6 @@ public class Query {
 	private Member writer;
 
 	@ManyToOne
-	@JoinColumn(name = "d_day_id", nullable = false)
-	private DDay dDay;
+	@JoinColumn(nullable = false)
+	private Subject subject;
 }


### PR DESCRIPTION
## 에러

첫글자만 소문자인 경우 자바 빈 네이밍 컨벤션에 어긋나 에러 발생

## 해결

- `dDay`를 사용한 모든 필드 및 메소드 -> `dday` 로 이름 변경
- `DDay` 엔티티 -> `Subject` 로 이름 변경

resolved: 