### PR TITLE
[Feat] 칭호(Title) API

### DIFF
--- a/src/main/java/efub/eday/edayback/domain/day/title/controller/TitleController.java
+++ b/src/main/java/efub/eday/edayback/domain/day/title/controller/TitleController.java
@@ -1,0 +1,25 @@
+package efub.eday.edayback.domain.day.title.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import efub.eday.edayback.domain.day.title.dto.TitleResponseDto;
+import efub.eday.edayback.domain.day.title.service.TitleService;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/title")
+@RequiredArgsConstructor
+public class TitleController {
+
+	private final TitleService titleService;
+
+	@GetMapping("/{member_id}")
+	public ResponseEntity<TitleResponseDto> getTitlePage(@PathVariable("member_id") Long memberId) {
+		TitleResponseDto titleResponseDto = titleService.getTitlePage(memberId);
+		return ResponseEntity.ok(titleResponseDto);
+	}
+}

--- a/src/main/java/efub/eday/edayback/domain/day/title/dto/MemberProfileDto.java
+++ b/src/main/java/efub/eday/edayback/domain/day/title/dto/MemberProfileDto.java
@@ -1,0 +1,28 @@
+package efub.eday.edayback.domain.day.title.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberProfileDto {
+
+	private String nickname;
+	private String email;
+	private String profileImage;
+	private int level;
+	private LocalDateTime createdDate;
+	private boolean isActive;
+
+	public MemberProfileDto(String nickname, String email, String profileImage, int level, LocalDateTime createdDate,
+		boolean isActive) {
+		this.nickname = nickname;
+		this.email = email;
+		this.profileImage = profileImage;
+		this.level = level;
+		this.createdDate = createdDate;
+		this.isActive = isActive;
+	}
+}

--- a/src/main/java/efub/eday/edayback/domain/day/title/dto/TitleDto.java
+++ b/src/main/java/efub/eday/edayback/domain/day/title/dto/TitleDto.java
@@ -1,0 +1,21 @@
+package efub.eday.edayback.domain.day.title.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TitleDto {
+
+	private int dday;
+	private String titleName;
+	private String titleImageUrl;
+	private boolean getTitle;
+
+	public TitleDto(int dday, String titleName, String titleImageUrl, boolean getTitle) {
+		this.dday = dday;
+		this.titleName = titleName;
+		this.titleImageUrl = titleImageUrl;
+		this.getTitle = getTitle;
+	}
+}

--- a/src/main/java/efub/eday/edayback/domain/day/title/dto/TitleResponseDto.java
+++ b/src/main/java/efub/eday/edayback/domain/day/title/dto/TitleResponseDto.java
@@ -1,0 +1,19 @@
+package efub.eday.edayback.domain.day.title.dto;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TitleResponseDto {
+
+	private MemberProfileDto profile;
+	private List<TitleDto> titleList;
+
+	public TitleResponseDto(MemberProfileDto profile, List<TitleDto> titleList) {
+		this.profile = profile;
+		this.titleList = titleList;
+	}
+}

--- a/src/main/java/efub/eday/edayback/domain/day/title/entity/Title.java
+++ b/src/main/java/efub/eday/edayback/domain/day/title/entity/Title.java
@@ -8,8 +8,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
+@Getter
 public class Title {
 
 	@Id
@@ -26,4 +31,11 @@ public class Title {
 	@OneToOne
 	@JoinColumn(nullable = false)
 	private Subject subject;
+
+	@Builder
+	public Title(String name, String imageUrl, Subject subject) {
+		this.name = name;
+		this.imageUrl = imageUrl;
+		this.subject = subject;
+	}
 }

--- a/src/main/java/efub/eday/edayback/domain/day/title/repository/MemberTitleRepository.java
+++ b/src/main/java/efub/eday/edayback/domain/day/title/repository/MemberTitleRepository.java
@@ -1,0 +1,14 @@
+package efub.eday.edayback.domain.day.title.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import efub.eday.edayback.domain.member.entity.Member;
+import efub.eday.edayback.domain.member.entity.MemberTitle;
+
+@Repository
+public interface MemberTitleRepository extends JpaRepository<MemberTitle, Long> {
+	List<MemberTitle> findByMember(Member member);
+}

--- a/src/main/java/efub/eday/edayback/domain/day/title/service/TitleService.java
+++ b/src/main/java/efub/eday/edayback/domain/day/title/service/TitleService.java
@@ -1,0 +1,56 @@
+package efub.eday.edayback.domain.day.title.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import efub.eday.edayback.domain.day.title.dto.MemberProfileDto;
+import efub.eday.edayback.domain.day.title.dto.TitleDto;
+import efub.eday.edayback.domain.day.title.dto.TitleResponseDto;
+import efub.eday.edayback.domain.day.title.entity.Title;
+import efub.eday.edayback.domain.day.title.repository.MemberTitleRepository;
+import efub.eday.edayback.domain.member.entity.Member;
+import efub.eday.edayback.domain.member.entity.MemberTitle;
+import efub.eday.edayback.domain.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TitleService {
+
+	private final MemberRepository memberRepository;
+	private final MemberTitleRepository memberTitleRepository;
+
+	@Transactional(readOnly = true)
+	public TitleResponseDto getTitlePage(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("해당하는 회원이 없습니다. ID: " + memberId));
+
+		List<MemberTitle> memberTitles = memberTitleRepository.findByMember(member);
+
+		MemberProfileDto profile = new MemberProfileDto(
+			member.getNickname(),
+			member.getEmail(),
+			member.getProfileImageUrl(),
+			member.getLevel(),
+			member.getCreatedDate().atStartOfDay(),
+			member.getIsActive()
+		);
+
+		List<TitleDto> titleList = memberTitles.stream()
+			.map(memberTitle -> {
+				Title title = memberTitle.getTitle();
+				return new TitleDto(
+					title.getSubject().getDday(),
+					title.getName(),
+					title.getImageUrl(),
+					memberTitle.getGetTitle()
+				);
+			})
+			.collect(Collectors.toList());
+
+		return new TitleResponseDto(profile, titleList);
+	}
+}

--- a/src/main/java/efub/eday/edayback/domain/member/entity/MemberTitle.java
+++ b/src/main/java/efub/eday/edayback/domain/member/entity/MemberTitle.java
@@ -8,8 +8,13 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class MemberTitle {
 
 	@Id
@@ -27,4 +32,11 @@ public class MemberTitle {
 	@ManyToOne
 	@JoinColumn(name = "title_id", nullable = false)
 	private Title title;
+
+	@Builder
+	public MemberTitle(Boolean getTitle, Member member, Title title) {
+		this.getTitle = getTitle;
+		this.member = member;
+		this.title = title;
+	}
 }


### PR DESCRIPTION
# 구현 기능
회원별(Member) 칭호(Title) 페이지 보는 기능입니다.  

# 구현 상태
Postman에서 테스트했을 때, DB에 저장된 것을 확인하였습니다.
![image](https://github.com/EFUB-EDAY/EDAY-BACK/assets/96541582/5ff9ca66-3697-426d-885c-e84455b43a57)
![image](https://github.com/EFUB-EDAY/EDAY-BACK/assets/96541582/f91e549b-c7c0-4fb9-ab51-8c4847e8e344)

# Resolve
#7 